### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   release:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
 
     strategy:
       matrix:

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -4,6 +4,10 @@ on: [pull_request, issues]
 
 jobs:
   greeting:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/first-interaction@v1


### PR DESCRIPTION
Potential fix for [https://github.com/mamarguerat/mixo/security/code-scanning/2](https://github.com/mamarguerat/mixo/security/code-scanning/2)

In general, the fix is to add an explicit `permissions:` block that grants only the scopes needed by this workflow, instead of relying on repository defaults. This can be done either at the workflow root (applies to all jobs) or at the job level. Since there is only one job (`release`), adding `permissions:` under that job is clear and minimally invasive.

The `samuelmeuli/action-electron-builder@v1` action uses the provided `github_token` to create GitHub releases and upload release assets when `release: true`. For that, it needs at least `contents: write` (to create releases and upload assets). It does not need broader scopes like `actions`, `admin`, or `packages`. The safest, functionality‑preserving change is therefore to add:

```yaml
permissions:
  contents: write
```

to the `release` job. Concretely, in `.github/workflows/build.yml`, under line 16 (`release:`) and line 17 (`runs-on: ${{ matrix.os }}`), insert a `permissions:` block at the same indentation level as `runs-on:`. No additional imports or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
